### PR TITLE
Update values of options variables to match the names.

### DIFF
--- a/aws/cfn/bridge/resources.py
+++ b/aws/cfn/bridge/resources.py
@@ -36,8 +36,8 @@ _OPTION_DELETE_ACTION = 'delete_action'
 _OPTION_UPDATE_ACTION = 'update_action'
 
 _OPTION_CREATE_TIMEOUT = 'create_timeout'
-_OPTION_DELETE_TIMEOUT = 'create_timeout'
-_OPTION_UPDATE_TIMEOUT = 'create_timeout'
+_OPTION_DELETE_TIMEOUT = 'delete_timeout'
+_OPTION_UPDATE_TIMEOUT = 'update_timeout'
 _OPTION_TIMEOUT = 'timeout'
 
 _OPTION_FLATTEN = 'flatten'


### PR DESCRIPTION
From the names of the timeout options variables the values are wrong. This change creates the 'delete' and 'update' timeout options.
