### PR TITLE
add setup config file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[bdist_rpm]
+install_script=rpm_support/install.sh
+post_install=rpm_support/postinstall.sh
+post_uninstall=rpm_support/postun.sh
+prep_script=rpm_support/prep.sh
+pre_uninstall=rpm_support/preun.sh


### PR DESCRIPTION
when trying to build a rpm using 'python setup.py bdist_rpm', we found that the spec file being generated only had the default content for install,prep,postinstall, etc. this caused the files to be installed not under /opt/aws and the init script to not be linked to /etc/init.d (on redhat at least)

by including this setup.cfg file now the spec file includes the rpm_support scripts content and the resulting rpm is installed to the intended location and the init script is linked.

if there already is a simpler solution, please document it in the readme.
