### PR TITLE
remove extra check for non-existant messages array in aws response

### DIFF
--- a/aws/cfn/bridge/runner.py
+++ b/aws/cfn/bridge/runner.py
@@ -126,7 +126,7 @@ class QueuePollTask(BaseTask):
                                                     max_number_of_messages=max_events)
 
         # Swallow up any errors/issues, logging them out
-        if http_response.status_code != 200 or not "Messages" in response_data:
+        if http_response.status_code != 200:
             log.error(u"Failed to retrieve messages from queue %s with status_code %s: %s" %
                       (self._queue_url, http_response.status_code, response_data))
             return []


### PR DESCRIPTION
we found that the latest aws sqs api does not return an empty Messages[] block when there are no messages in the queue. instead it returns no message body with http response code 200. we were getting errors in the log as such:
2015-04-02 21:22:37,574 [ERROR] Failed to retrieve messages from queue https://sqs.us-east-1.amazonaws.com/01234567890/AbcQueue-1ABCDEFQ with status_code 200: {'ResponseMetadata': {'HTTPStatusCode': 200, 'RequestId': '3b3ca2a8-5f14-5ac1-8b1f-ef3fea5dc376'}}

we validated the differences by querying via the aws cli v1.1.0:
AWS_DEFAULT_REGION=us-east-1 aws sqs receive-message --queue-url https://sqs.us-east-1.amazonaws.com/01234567890/AbcQueue-1ABCDEFQ --wait-time-seconds 2 --max-number-of-messages 1 --output json
{  
    "Messages": []
}

for comparison here is part of the debug response from the latest aws cli (v1.7.18):
AWS_DEFAULT_REGION=us-east-1 aws sqs receive-message --queue-url https://sqs.us-east-1.amazonaws.com/01234567890/AbcQueue-1ABCDEFQ --wait-time-seconds 2 --max-number-of-messages 1 --output json --debug
...
2015-04-03 22:52:55,722 - MainThread - botocore.parsers - DEBUG - Response body:
<?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult/><ResponseMetadata><RequestId>99c90e95-aa76-5c97-9983-430cb6736cf6</RequestId></ResponseMetadata></ReceiveMessageResponse>
...

our propsed change is just to remove the additional check, the code should proceed normally and return an empty result.
